### PR TITLE
Use relative URLs in index

### DIFF
--- a/mjpeg_streamer/mjpeg_streamer.py
+++ b/mjpeg_streamer/mjpeg_streamer.py
@@ -118,7 +118,7 @@ class MjpegServer:
     async def __root_handler(self, _) -> web.Response:
         text = "<h2>Available streams:</h2>"
         for route in self._cap_routes:
-            text += f"<a href='http://{self._host[0]}:{self._port}{route}'>{route}</a>\n<br>\n"
+            text += f"<a href='{route}'>{route}</a>\n<br>\n"
         return aiohttp.web.Response(text=text, content_type="text/html")
 
     def add_stream(self, stream: Stream) -> None:


### PR DESCRIPTION
When viewing the index relative URLs should be used in case multiple IP addresses exist (in my case both local host, and local network).

The existing code can send you to a loopback address even when viewing over the network.