### PR TITLE
Add audio streaming support with browser player

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-The mjpeg-streamer package provides a simple, flexible and efficient way to stream MJPEG video from OpenCV-compatible sources over HTTP. It provides a flexible interface that allows users to specify the video source and configure various parameters such as image size, quality, and FPS.
+The mjpeg-streamer package provides a simple, flexible and efficient way to stream MJPEG video and audio from OpenCV-compatible sources over HTTP. It supports multiple video streams, audio streaming via PyAudio, and includes a built-in browser player for synced audio+video playback.
 
 
 ## Installation
@@ -22,10 +22,22 @@ pip install mjpeg-streamer --prefer-binary
 
 *Latest versions of dependencies (e.g. Numpy) don't always ship with pre-compiled binaries for older versions of Python, so this option installs the latest compatible version instead, even though it might be a bit older.*
 
+### Audio Support
+
+To enable audio streaming, install with the `audio` extra:
+
+```bash
+pip install mjpeg-streamer[audio]
+```
+
+This installs [PyAudio](https://pypi.org/project/PyAudio/), which is required for capturing and streaming audio from input devices.
+
 
 ## Usage
 
 ### Library
+
+#### Video Only
 
 Here's a simple example that shows how to use the *mjpeg_streamer* package to stream video from a webcam:
 
@@ -64,9 +76,61 @@ Don't forget to check out the [examples](examples) directory for more examples.
 
 Check out the [class reference](#class-reference) for more details on the classes and methods provided by the package.
 
+#### Video + Audio
+
+```python
+import cv2
+from mjpeg_streamer import AudioStream, MjpegServer, Stream
+
+cap = cv2.VideoCapture(0)
+
+video = Stream("camera", size=(640, 480), quality=50, fps=30)
+audio = AudioStream("microphone")
+
+server = MjpegServer("localhost", 8080)
+server.add_stream(video)
+server.add_stream(audio)
+server.start()
+
+print("Open http://localhost:8080/player in your browser")
+
+while True:
+    _, frame = cap.read()
+    video.set_frame(frame)
+    if cv2.waitKey(1) == ord("q"):
+        break
+
+audio.stop()
+server.stop()
+cap.release()
+cv2.destroyAllWindows()
+```
+
+This streams both webcam video and microphone audio. Open http://localhost:8080/player in your browser to view the synced player with volume controls.
+
+#### ManagedStream (Auto-Capture)
+
+`ManagedStream` wraps a `cv2.VideoCapture` and reads frames automatically, supporting on-demand capture modes:
+
+```python
+import cv2
+from mjpeg_streamer import ManagedStream, MjpegServer
+
+# fast-on-demand: always captures (default)
+# full-on-demand: only captures when viewers are connected
+stream = ManagedStream("camera", source=0, fps=30, size=(640, 480), mode="full-on-demand")
+
+server = MjpegServer("localhost", 8080)
+server.add_stream(stream)
+stream.start()
+server.start()
+```
+
 ### Command Line Interface
 
-The package also provides a simple command line interface that allows you to stream video from multiple sources using a single command. Here's an example that shows how to stream video from a webcam and a video file:
+The package also provides a simple command line interface that allows you to stream video from multiple sources using a single command.
+
+#### Video Only
 
 ```bash
 $ mjpeg-streamer -s 0 -s "video file.mp4" --prefix "ender 3 pro" --quality 75 --fps 24 --show-bandwidth
@@ -84,11 +148,36 @@ Press Ctrl+C to stop the server
 ender_3_pro_video_file_mp4: 599.28 KB/s | ender_3_pro_0: 824.44 KB/s
 ```
 
-This command starts the MJPEG server on ``localhost:8080`` and streams video from the webcam with the index of ``0`` and the video file ``video file.mp4``. The streams are prefixed with ``ender 3 pro`` and compressed with JPEG quality of 75 and streamed at 24 FPS. The bandwidth of each stream is displayed in the console.
+#### Video + Audio
 
-To view the video streams, you can open a web browser and navigate to the URLs displayed in the console.
+```bash
+$ mjpeg-streamer -s 0 --audio --show-bandwidth
+```
 
-Run ``mjpeg-streamer --help`` for more information on the available options.
+This streams webcam video with microphone audio. The player URL will be printed in the console.
+
+#### List Audio Devices
+
+To see available audio input devices and their indices:
+
+```bash
+$ mjpeg-streamer --list-devices
+
+Audio input devices:
+
+  [0] Microsoft Sound Mapper - Input
+       Channels: 2, Rate: 44100 Hz
+  [1] Microphone (C-Media(R) Audio)
+       Channels: 2, Rate: 44100 Hz
+```
+
+Then use the device index with `--audio-device`:
+
+```bash
+$ mjpeg-streamer -s 0 --audio --audio-device 1
+```
+
+Run ``mjpeg-streamer --help`` for all available options.
 
 ***Note that*** the command line interface is limited and doesn't provide the same level of flexibility as the library. It's recommended to use the library if you need to customize the video streams or integrate them into your own application.
 
@@ -146,9 +235,59 @@ Creates a new Stream instance with the given unique name, image size, JPEG quali
 
     Returns the current frame as a Numpy array after processing it with the specified image size and JPEG quality.
 
+### *ManagedStream*
+A class that manages its own video capture, automatically reading frames from a source (webcam index, video file path, etc.).
+
+***Constructor:***
+
+```python
+ManagedStream(
+    name: str,
+    source: Union[int, str] = 0,
+    fps: int = 30,
+    size: Optional[Tuple[int, int]] = None,
+    quality: int = 50,
+    mode: str = "fast-on-demand",
+    poll_delay_ms: Optional[Union[float, int]] = None,
+)
+```
+
+Creates a new ManagedStream instance. `mode` can be `"fast-on-demand"` (always capturing) or `"full-on-demand"` (only captures when viewers are connected).
+
+***Methods:***
+
+- *start* / *stop* - Start or stop the capture loop.
+- *set_size* / *set_quality* - Adjust output dimensions or JPEG quality.
+- *change_mode* - Switch between on-demand modes at runtime.
+- *change_source* - Switch the video capture source.
+
+### *AudioStream*
+A class that captures and streams audio from an input device as WAV over HTTP. Requires the `pyaudio` extra.
+
+***Constructor:***
+
+```python
+AudioStream(
+    name: str,
+    source: Optional[int] = None,
+    sample_rate: int = 44100,
+    channels: int = 1,
+    sample_width: int = 2,
+    chunk_size: int = 1024,
+)
+```
+
+Creates a new AudioStream instance. If `source` is `None`, the system default input device is used.
+
+***Methods:***
+
+- *start* / *stop* - Start or stop audio capture.
+- *get_bandwidth* - Returns the bandwidth of the stream in bytes per second.
+- *active_viewers* - Returns the number of active viewers.
+
 ### *MjpegServer*
 
-A class that represents an MJPEG server. The server can serve multiple video streams, each identified by a unique name.
+A class that represents an MJPEG server. The server can serve multiple video and audio streams, each identified by a unique name.
 
 ***Constructor:***
 
@@ -163,10 +302,10 @@ Creates a new MjpegServer instance with the given host and port.
 - *add_stream*
 
     ```python
-    add_stream(stream: Stream)
+    add_stream(stream: Union[Stream, ManagedStream, AudioStream])
     ```
 
-    Adds a new video stream to the server.
+    Adds a new video or audio stream to the server.
 
 <br>
 

--- a/examples/audio_video.py
+++ b/examples/audio_video.py
@@ -1,0 +1,31 @@
+"""Example: Stream webcam video + microphone audio together."""
+
+import cv2
+from mjpeg_streamer import AudioStream, MjpegServer, Stream
+
+# Video source (webcam 0)
+cap = cv2.VideoCapture(0)
+
+# Video stream
+video = Stream("camera", size=(640, 480), quality=50, fps=30)
+
+# Audio stream (default microphone)
+audio = AudioStream("microphone")
+
+server = MjpegServer("localhost", 8080)
+server.add_stream(video)
+server.add_stream(audio)
+server.start()
+
+print("Open http://localhost:8080/player in your browser")
+
+while True:
+    _, frame = cap.read()
+    video.set_frame(frame)
+    if cv2.waitKey(1) == ord("q"):
+        break
+
+audio.stop()
+server.stop()
+cap.release()
+cv2.destroyAllWindows()

--- a/mjpeg_streamer/__init__.py
+++ b/mjpeg_streamer/__init__.py
@@ -1,5 +1,12 @@
 from .server import MjpegServer, Server
-from .stream import ManagedStream, Stream, StreamBase
+from .stream import AudioStream, ManagedStream, Stream, StreamBase
 
-__all__ = ["StreamBase", "ManagedStream", "MjpegServer", "Stream", "Server"]
+__all__ = [
+    "AudioStream",
+    "ManagedStream",
+    "MjpegServer",
+    "Stream",
+    "StreamBase",
+    "Server",
+]
 __version__ = "2024.2.8"

--- a/mjpeg_streamer/cli.py
+++ b/mjpeg_streamer/cli.py
@@ -4,7 +4,7 @@ import time
 from typing import Dict, List, Tuple, Union
 
 from .server import Server
-from .stream import ManagedStream
+from .stream import AudioStream, ManagedStream
 
 
 def parse_args() -> argparse.Namespace:
@@ -31,6 +31,34 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Shows the bandwidth used by each stream in kilobytes per second",
     )
+    parser.add_argument(
+        "--audio",
+        action="store_true",
+        help="Enable audio streaming (requires pyaudio)",
+    )
+    parser.add_argument(
+        "--audio-device",
+        type=int,
+        default=None,
+        help="Audio input device index (default: system default)",
+    )
+    parser.add_argument(
+        "--audio-rate",
+        type=int,
+        default=44100,
+        help="Audio sample rate in Hz (default: 44100)",
+    )
+    parser.add_argument(
+        "--audio-channels",
+        type=int,
+        default=1,
+        help="Number of audio channels (default: 1)",
+    )
+    parser.add_argument(
+        "--list-devices",
+        action="store_true",
+        help="List available audio input devices and exit",
+    )
     args: argparse.Namespace = parser.parse_args()
     args.prefix = re.sub("[^0-9a-zA-Z]+", "_", args.prefix)
     args.source = [[0]] if args.source is None else args.source
@@ -41,8 +69,29 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
+
+    if args.list_devices:
+        try:
+            import pyaudio
+
+            pa = pyaudio.PyAudio()
+            print("Audio input devices:\n")
+            for i in range(pa.get_device_count()):
+                info = pa.get_device_info_by_index(i)
+                if info["maxInputChannels"] > 0:
+                    print(f"  [{i}] {info['name']}")
+                    print(
+                        f"       Channels: {int(info['maxInputChannels'])}, "
+                        f"Rate: {int(info['defaultSampleRate'])} Hz"
+                    )
+            pa.terminate()
+        except ImportError:
+            print("pyaudio is not installed. Install it with: pip install pyaudio")
+        return
+
     size: Tuple[int, int] = (args.width, args.height)
     streams: List[ManagedStream] = []
+    audio_streams: List[AudioStream] = []
     server = Server(args.host, args.port)
 
     if args.show_bandwidth:
@@ -63,14 +112,33 @@ def main() -> None:
         server.add_stream(stream)
         streams.append(stream)
 
+    if args.audio:
+        try:
+            audio_stream = AudioStream(
+                name=f"{args.prefix}{'_' if args.prefix else ''}audio",
+                source=args.audio_device,
+                sample_rate=args.audio_rate,
+                channels=args.audio_channels,
+            )
+            server.add_stream(audio_stream)
+            audio_streams.append(audio_stream)
+        except ImportError as e:
+            print(f"Audio not available: {e}")
+        except Exception as e:
+            print(f"Audio setup error: {e}")
+
     try:
         for stream in streams:
             stream.start()
+        for astream in audio_streams:
+            astream.start()
         server.start()
         while True:
             if args.show_bandwidth:
                 for stream in streams:
                     bandwidth[stream.name] = stream.get_bandwidth()
+                for astream in audio_streams:
+                    bandwidth[astream.name] = astream.get_bandwidth()
                 print(
                     f"{' | '.join([f'{k}: {round(v / 1024, 2)} KB/s' for k, v in bandwidth.items()])}",
                     end="\r",
@@ -84,6 +152,8 @@ def main() -> None:
     finally:
         for stream in streams:
             stream.stop()
+        for astream in audio_streams:
+            astream.stop()
         server.stop()
 
 

--- a/mjpeg_streamer/cli.py
+++ b/mjpeg_streamer/cli.py
@@ -33,14 +33,12 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--audio",
-        action="store_true",
-        help="Enable audio streaming (requires pyaudio)",
-    )
-    parser.add_argument(
-        "--audio-device",
-        type=int,
+        action="append",
+        nargs="?",
+        const=None,
         default=None,
-        help="Audio input device index (default: system default)",
+        metavar="DEVICE",
+        help="Enable audio streaming. Optionally pass a device index (repeatable, e.g. --audio 0 --audio 1)",
     )
     parser.add_argument(
         "--audio-rate",
@@ -114,14 +112,21 @@ def main() -> None:
 
     if args.audio:
         try:
-            audio_stream = AudioStream(
-                name=f"{args.prefix}{'_' if args.prefix else ''}audio",
-                source=args.audio_device,
-                sample_rate=args.audio_rate,
-                channels=args.audio_channels,
-            )
-            server.add_stream(audio_stream)
-            audio_streams.append(audio_stream)
+            for i, device in enumerate(args.audio):
+                device_index = int(device) if device is not None else None
+                name = (
+                    f"{args.prefix}{'_' if args.prefix else ''}audio_{device_index}"
+                    if device_index is not None
+                    else f"{args.prefix}{'_' if args.prefix else ''}audio"
+                )
+                audio_stream = AudioStream(
+                    name=name,
+                    source=device_index,
+                    sample_rate=args.audio_rate,
+                    channels=args.audio_channels,
+                )
+                server.add_stream(audio_stream)
+                audio_streams.append(audio_stream)
         except ImportError as e:
             print(f"Audio not available: {e}")
         except Exception as e:

--- a/mjpeg_streamer/player.py
+++ b/mjpeg_streamer/player.py
@@ -10,6 +10,8 @@ class PlayerHandler:
         audio_streams = self._server._audio_routes
         host = self._server._host[0]
         port = self._server._port
+        has_video = len(video_streams) > 0
+        has_audio = len(audio_streams) > 0
 
         video_options = "\n".join(
             f'<option value="http://{host}:{port}{r}">{r.lstrip("/")}</option>'
@@ -19,6 +21,26 @@ class PlayerHandler:
             f'<option value="http://{host}:{port}{r}">{r.lstrip("/")}</option>'
             for r in audio_streams
         )
+
+        video_section = ""
+        video_js = ""
+        if has_video:
+            video_section = """
+  <div class="player" id="videoPlayer">
+    <img id="video" alt="video stream">
+    <div class="status" id="status">Stopped</div>
+  </div>"""
+            video_js = """
+  const videoImg = document.getElementById('video');
+  const statusEl = document.getElementById('status');
+  const videoSelect = document.getElementById('videoSelect');"""
+
+        controls_html = ""
+        if has_video:
+            controls_html += '  <select id="videoSelect">{video_options}</select>\n'
+        if has_audio:
+            controls_html += '  <select id="audioSelect"><option value="">No audio</option>{audio_options}</select>\n'
+        controls_html += '  <button id="playBtn">Play</button>'
 
         html = f"""<!DOCTYPE html>
 <html lang="en">
@@ -40,19 +62,18 @@ class PlayerHandler:
   .status.error {{ color: #f44; }}
   .volume {{ display: flex; align-items: center; gap: 6px; margin-top: 10px; }}
   .volume input[type=range] {{ width: 120px; accent-color: #e94560; }}
+  .audio-only {{ background: #16213e; border-radius: 8px; padding: 30px 40px; text-align: center; margin: 10px 0; }}
+  .audio-only .icon {{ font-size: 3rem; margin-bottom: 10px; }}
+  .audio-only .label {{ color: #aaa; font-size: 0.9rem; }}
 </style>
 </head>
 <body>
 <h1>Stream Player</h1>
 <div class="controls">
-  <select id="videoSelect">{video_options}</select>
-  <select id="audioSelect"><option value="">No audio</option>{audio_options}</select>
-  <button id="playBtn">Play</button>
+{controls_html.format(video_options=video_options, audio_options=audio_options)}
 </div>
-<div class="player">
-  <img id="video" alt="video stream">
-  <div class="status" id="status">Stopped</div>
-</div>
+{video_section}
+{"<div class='audio-only' id='audioPlayer'><div class='icon'>&#9835;</div><div class='label'>Audio stream</div></div>" if not has_video else ""}
 <div class="volume">
   <label for="volumeSlider">Vol:</label>
   <input type="range" id="volumeSlider" min="0" max="1" step="0.05" value="1">
@@ -60,40 +81,36 @@ class PlayerHandler:
 </div>
 <audio id="audio" autoplay></audio>
 <script>
-  const videoImg = document.getElementById('video');
+  {video_js}
   const audioEl = document.getElementById('audio');
-  const statusEl = document.getElementById('status');
-  const videoSelect = document.getElementById('videoSelect');
-  const audioSelect = document.getElementById('audioSelect');
   const playBtn = document.getElementById('playBtn');
   const volumeSlider = document.getElementById('volumeSlider');
   const volumeVal = document.getElementById('volumeVal');
   let playing = false;
+  {'const audioSelect = document.getElementById("audioSelect");' if has_audio else ''}
 
   function startStreams() {{
-    const vUrl = videoSelect.value;
-    if (!vUrl) return;
-    videoImg.src = vUrl;
-    const aUrl = audioSelect.value;
-    if (aUrl) {{
+    {'const vUrl = videoSelect.value;' if has_video else ''}
+    {'if (!vUrl) return;' if has_video else ''}
+    {f'videoImg.src = vUrl;' if has_video else ''}
+    {'const aUrl = audioSelect.value;' if has_audio else ''}
+    {f'''if (aUrl) {{
       audioEl.src = aUrl;
       audioEl.play().catch(() => {{}});
     }} else {{
       audioEl.src = '';
-    }}
-    statusEl.textContent = 'Playing';
-    statusEl.className = 'status';
+    }}''' if has_audio else ''}
+    {f"statusEl.textContent = 'Playing'; statusEl.className = 'status';" if has_video else ''}
     playing = true;
     playBtn.textContent = 'Stop';
     playBtn.classList.add('active');
   }}
 
   function stopStreams() {{
-    videoImg.src = '';
+    {f"videoImg.src = '';" if has_video else ''}
     audioEl.pause();
     audioEl.src = '';
-    statusEl.textContent = 'Stopped';
-    statusEl.className = 'status error';
+    {f"statusEl.textContent = 'Stopped'; statusEl.className = 'status error';" if has_video else ''}
     playing = false;
     playBtn.textContent = 'Play';
     playBtn.classList.remove('active');
@@ -103,24 +120,9 @@ class PlayerHandler:
     playing ? stopStreams() : startStreams();
   }});
 
-  videoSelect.addEventListener('change', () => {{
-    if (playing) {{
-      videoImg.src = videoSelect.value;
-    }}
-  }});
+  {'videoSelect.addEventListener("change", () => {{ if (playing) {{ videoImg.src = videoSelect.value; }} }});' if has_video else ''}
 
-  audioSelect.addEventListener('change', () => {{
-    if (playing) {{
-      const aUrl = audioSelect.value;
-      if (aUrl) {{
-        audioEl.src = aUrl;
-        audioEl.play().catch(() => {{}});
-      }} else {{
-        audioEl.pause();
-        audioEl.src = '';
-      }}
-    }}
-  }});
+  {'audioSelect.addEventListener("change", () => {{ if (playing) {{ const aUrl = audioSelect.value; if (aUrl) {{ audioEl.src = aUrl; audioEl.play().catch(() => {{}}); }} else {{ audioEl.pause(); audioEl.src = ""; }} }} }});' if has_audio else ''}
 
   volumeSlider.addEventListener('input', () => {{
     const v = parseFloat(volumeSlider.value);
@@ -129,19 +131,14 @@ class PlayerHandler:
   }});
 
   audioEl.addEventListener('playing', () => {{
-    statusEl.textContent = 'Playing (audio synced)';
+    {f"statusEl.textContent = 'Playing (audio synced)';" if has_video else ''}
   }});
 
   audioEl.addEventListener('error', () => {{
-    if (playing) statusEl.textContent = 'Playing (video only)';
+    {f"if (playing) statusEl.textContent = 'Playing (video only)';" if has_video else ''}
   }});
 
-  videoImg.addEventListener('error', () => {{
-    if (playing) {{
-      statusEl.textContent = 'Connection lost';
-      statusEl.className = 'status error';
-    }}
-  }});
+  {'videoImg.addEventListener("error", () => {{ if (playing) {{ statusEl.textContent = "Connection lost"; statusEl.className = "status error"; }} }});' if has_video else ''}
 </script>
 </body>
 </html>"""

--- a/mjpeg_streamer/player.py
+++ b/mjpeg_streamer/player.py
@@ -1,0 +1,148 @@
+from aiohttp import web
+
+
+class PlayerHandler:
+    def __init__(self, server) -> None:
+        self._server = server
+
+    async def __call__(self, request: web.Request) -> web.Response:
+        video_streams = self._server._cap_routes
+        audio_streams = self._server._audio_routes
+        host = self._server._host[0]
+        port = self._server._port
+
+        video_options = "\n".join(
+            f'<option value="http://{host}:{port}{r}">{r.lstrip("/")}</option>'
+            for r in video_streams
+        )
+        audio_options = "\n".join(
+            f'<option value="http://{host}:{port}{r}">{r.lstrip("/")}</option>'
+            for r in audio_streams
+        )
+
+        html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Stream Player</title>
+<style>
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{ background: #1a1a2e; color: #eee; font-family: system-ui, sans-serif; display: flex; flex-direction: column; align-items: center; min-height: 100vh; padding: 20px; }}
+  h1 {{ margin-bottom: 16px; font-size: 1.4rem; color: #e94560; }}
+  .controls {{ display: flex; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; justify-content: center; }}
+  select, button {{ padding: 8px 14px; border: 1px solid #333; border-radius: 6px; background: #16213e; color: #eee; font-size: 0.9rem; cursor: pointer; }}
+  select:hover, button:hover {{ border-color: #e94560; }}
+  button.active {{ background: #e94560; border-color: #e94560; }}
+  .player {{ position: relative; background: #000; border-radius: 8px; overflow: hidden; max-width: 90vw; }}
+  #video {{ display: block; max-width: 90vw; max-height: 80vh; object-fit: contain; }}
+  .status {{ position: absolute; top: 8px; left: 8px; background: rgba(0,0,0,0.7); padding: 4px 10px; border-radius: 4px; font-size: 0.75rem; color: #0f0; }}
+  .status.error {{ color: #f44; }}
+  .volume {{ display: flex; align-items: center; gap: 6px; margin-top: 10px; }}
+  .volume input[type=range] {{ width: 120px; accent-color: #e94560; }}
+</style>
+</head>
+<body>
+<h1>Stream Player</h1>
+<div class="controls">
+  <select id="videoSelect">{video_options}</select>
+  <select id="audioSelect"><option value="">No audio</option>{audio_options}</select>
+  <button id="playBtn">Play</button>
+</div>
+<div class="player">
+  <img id="video" alt="video stream">
+  <div class="status" id="status">Stopped</div>
+</div>
+<div class="volume">
+  <label for="volumeSlider">Vol:</label>
+  <input type="range" id="volumeSlider" min="0" max="1" step="0.05" value="1">
+  <span id="volumeVal">100%</span>
+</div>
+<audio id="audio" autoplay></audio>
+<script>
+  const videoImg = document.getElementById('video');
+  const audioEl = document.getElementById('audio');
+  const statusEl = document.getElementById('status');
+  const videoSelect = document.getElementById('videoSelect');
+  const audioSelect = document.getElementById('audioSelect');
+  const playBtn = document.getElementById('playBtn');
+  const volumeSlider = document.getElementById('volumeSlider');
+  const volumeVal = document.getElementById('volumeVal');
+  let playing = false;
+
+  function startStreams() {{
+    const vUrl = videoSelect.value;
+    if (!vUrl) return;
+    videoImg.src = vUrl;
+    const aUrl = audioSelect.value;
+    if (aUrl) {{
+      audioEl.src = aUrl;
+      audioEl.play().catch(() => {{}});
+    }} else {{
+      audioEl.src = '';
+    }}
+    statusEl.textContent = 'Playing';
+    statusEl.className = 'status';
+    playing = true;
+    playBtn.textContent = 'Stop';
+    playBtn.classList.add('active');
+  }}
+
+  function stopStreams() {{
+    videoImg.src = '';
+    audioEl.pause();
+    audioEl.src = '';
+    statusEl.textContent = 'Stopped';
+    statusEl.className = 'status error';
+    playing = false;
+    playBtn.textContent = 'Play';
+    playBtn.classList.remove('active');
+  }}
+
+  playBtn.addEventListener('click', () => {{
+    playing ? stopStreams() : startStreams();
+  }});
+
+  videoSelect.addEventListener('change', () => {{
+    if (playing) {{
+      videoImg.src = videoSelect.value;
+    }}
+  }});
+
+  audioSelect.addEventListener('change', () => {{
+    if (playing) {{
+      const aUrl = audioSelect.value;
+      if (aUrl) {{
+        audioEl.src = aUrl;
+        audioEl.play().catch(() => {{}});
+      }} else {{
+        audioEl.pause();
+        audioEl.src = '';
+      }}
+    }}
+  }});
+
+  volumeSlider.addEventListener('input', () => {{
+    const v = parseFloat(volumeSlider.value);
+    audioEl.volume = v;
+    volumeVal.textContent = Math.round(v * 100) + '%';
+  }});
+
+  audioEl.addEventListener('playing', () => {{
+    statusEl.textContent = 'Playing (audio synced)';
+  }});
+
+  audioEl.addEventListener('error', () => {{
+    if (playing) statusEl.textContent = 'Playing (video only)';
+  }});
+
+  videoImg.addEventListener('error', () => {{
+    if (playing) {{
+      statusEl.textContent = 'Connection lost';
+      statusEl.className = 'status error';
+    }}
+  }});
+</script>
+</body>
+</html>"""
+        return web.Response(text=html, content_type="text/html")

--- a/mjpeg_streamer/server.py
+++ b/mjpeg_streamer/server.py
@@ -7,7 +7,7 @@ from aiohttp import MultipartWriter, web
 from aiohttp.web_runner import GracefulExit
 from multidict import MultiDict
 
-from .stream import StreamBase
+from .stream import AudioStream, StreamBase
 
 
 class _StreamHandler:
@@ -53,6 +53,48 @@ class _StreamHandler:
         return response
 
 
+class _AudioHandler:
+    def __init__(self, stream: AudioStream) -> None:
+        self._stream = stream
+
+    async def __call__(self, request: web.Request) -> web.StreamResponse:
+        viewer_token = request.cookies.get("viewer_token")
+        response = web.StreamResponse(
+            status=200,
+            reason="OK",
+            headers={
+                "Content-Type": "audio/wav",
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+            },
+        )
+        try:
+            await response.prepare(request)
+        except (ConnectionResetError, ConnectionAbortedError, ConnectionError):
+            pass
+        if not viewer_token:
+            viewer_token = await self._stream._add_viewer()
+            response.set_cookie("viewer_token", viewer_token)
+        elif viewer_token not in self._stream._active_viewers:
+            await self._stream._add_viewer(viewer_token)
+        try:
+            # Send WAV header first
+            header = self._stream._make_wav_header_bytes()
+            await response.write(header)
+            while True:
+                try:
+                    await asyncio.sleep(1.0 / (
+                        self._stream.sample_rate / self._stream.chunk_size
+                    ))
+                    chunk = self._stream._last_chunk
+                    if chunk:
+                        await response.write(chunk)
+                except (ConnectionResetError, ConnectionAbortedError, ConnectionError):
+                    break
+        finally:
+            await self._stream._remove_viewer(viewer_token)
+        return response
+
+
 class Server:
     def __init__(
         self, host: Union[str, List[str,]] = "localhost", port: int = 8080
@@ -71,6 +113,7 @@ class Server:
         self._app: web.Application = web.Application()
         self._app_is_running: bool = False
         self._cap_routes: List[str,] = []
+        self._audio_routes: List[str] = []
 
     def is_running(self) -> bool:
         return self._app_is_running
@@ -79,19 +122,39 @@ class Server:
         text = "<h2>Available streams:</h2>"
         for route in self._cap_routes:
             text += f"<a href='http://{self._host[0]}:{self._port}{route}'>{route}</a>\n<br>\n"
+        if self._audio_routes:
+            text += "<h2>Audio streams:</h2>"
+            for route in self._audio_routes:
+                text += f"<a href='http://{self._host[0]}:{self._port}{route}'>{route}</a>\n<br>\n"
+        if self._cap_routes and self._audio_routes:
+            text += f"<h2><a href='http://{self._host[0]}:{self._port}/player'>Player (synced audio+video)</a></h2>"
         return aiohttp.web.Response(text=text, content_type="text/html")
 
-    def add_stream(self, stream: StreamBase) -> None:
+    def add_stream(self, stream: Union[StreamBase, AudioStream]) -> None:
         if self.is_running():
             raise RuntimeError("Cannot add stream after the server has started")
         route = f"/{stream.name}"
-        if route in self._cap_routes:
-            raise ValueError(f"A stream with the name {route} already exists")
-        self._cap_routes.append(route)
-        self._app.router.add_route("GET", route, _StreamHandler(stream))
+        if isinstance(stream, AudioStream):
+            if route in self._audio_routes:
+                raise ValueError(f"An audio stream with the name {route} already exists")
+            self._audio_routes.append(route)
+            self._app.router.add_route("GET", route, _AudioHandler(stream))
+        else:
+            if route in self._cap_routes:
+                raise ValueError(f"A stream with the name {route} already exists")
+            self._cap_routes.append(route)
+            self._app.router.add_route("GET", route, _StreamHandler(stream))
+        if self._cap_routes and self._audio_routes:
+            from .player import PlayerHandler
+
+            self._app.router.add_route("GET", "/player", PlayerHandler(self))
 
     def __start_func(self) -> None:
         self._app.router.add_route("GET", "/", self.__root_handler)
+        if self._cap_routes and self._audio_routes:
+            from .player import PlayerHandler
+
+            self._app.router.add_route("GET", "/player", PlayerHandler(self))
         runner = web.AppRunner(self._app)
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -113,6 +176,14 @@ class Server:
             print("Available streams:\n")
             for route in self._cap_routes:  # route has a leading slash
                 print(f"http://{addr}:{self._port!s}{route}")
+            if self._audio_routes:
+                print("\nAudio streams:\n")
+                for route in self._audio_routes:
+                    print(f"http://{addr}:{self._port!s}{route}")
+            if self._cap_routes and self._audio_routes:
+                print(
+                    f"\nPlayer: http://{addr}:{self._port!s}/player"
+                )
             print("--------------------------------\n")
         print("\nPress Ctrl+C to stop the server\n")
 

--- a/mjpeg_streamer/server.py
+++ b/mjpeg_streamer/server.py
@@ -77,7 +77,11 @@ class _AudioHandler:
         elif viewer_token not in self._stream._active_viewers:
             await self._stream._add_viewer(viewer_token)
         try:
-            # Send WAV header first
+            # Wait for first chunk so the browser gets real audio immediately
+            try:
+                await asyncio.wait_for(self._stream._first_chunk_ready.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                pass
             header = self._stream._make_wav_header_bytes()
             await response.write(header)
             while True:

--- a/mjpeg_streamer/server.py
+++ b/mjpeg_streamer/server.py
@@ -79,7 +79,9 @@ class _AudioHandler:
         try:
             # Wait for first chunk so the browser gets real audio immediately
             try:
-                await asyncio.wait_for(self._stream._first_chunk_ready.wait(), timeout=5.0)
+                await asyncio.wait_for(
+                    self._stream._first_chunk_ready.wait(), timeout=5.0
+                )
             except asyncio.TimeoutError:
                 pass
             header = self._stream._make_wav_header_bytes()

--- a/mjpeg_streamer/server.py
+++ b/mjpeg_streamer/server.py
@@ -134,6 +134,8 @@ class Server:
                 text += f"<a href='http://{self._host[0]}:{self._port}{route}'>{route}</a>\n<br>\n"
         if self._cap_routes and self._audio_routes:
             text += f"<h2><a href='http://{self._host[0]}:{self._port}/player'>Player (synced audio+video)</a></h2>"
+        elif self._audio_routes:
+            text += f"<h2><a href='http://{self._host[0]}:{self._port}/player'>Player</a></h2>"
         return aiohttp.web.Response(text=text, content_type="text/html")
 
     def add_stream(self, stream: Union[StreamBase, AudioStream]) -> None:
@@ -152,14 +154,14 @@ class Server:
                 raise ValueError(f"A stream with the name {route} already exists")
             self._cap_routes.append(route)
             self._app.router.add_route("GET", route, _StreamHandler(stream))
-        if self._cap_routes and self._audio_routes:
+        if self._audio_routes:
             from .player import PlayerHandler
 
             self._app.router.add_route("GET", "/player", PlayerHandler(self))
 
     def __start_func(self) -> None:
         self._app.router.add_route("GET", "/", self.__root_handler)
-        if self._cap_routes and self._audio_routes:
+        if self._audio_routes:
             from .player import PlayerHandler
 
             self._app.router.add_route("GET", "/player", PlayerHandler(self))
@@ -188,7 +190,6 @@ class Server:
                 print("\nAudio streams:\n")
                 for route in self._audio_routes:
                     print(f"http://{addr}:{self._port!s}{route}")
-            if self._cap_routes and self._audio_routes:
                 print(f"\nPlayer: http://{addr}:{self._port!s}/player")
             print("--------------------------------\n")
         print("\nPress Ctrl+C to stop the server\n")

--- a/mjpeg_streamer/server.py
+++ b/mjpeg_streamer/server.py
@@ -82,9 +82,9 @@ class _AudioHandler:
             await response.write(header)
             while True:
                 try:
-                    await asyncio.sleep(1.0 / (
-                        self._stream.sample_rate / self._stream.chunk_size
-                    ))
+                    await asyncio.sleep(
+                        1.0 / (self._stream.sample_rate / self._stream.chunk_size)
+                    )
                     chunk = self._stream._last_chunk
                     if chunk:
                         await response.write(chunk)
@@ -136,7 +136,9 @@ class Server:
         route = f"/{stream.name}"
         if isinstance(stream, AudioStream):
             if route in self._audio_routes:
-                raise ValueError(f"An audio stream with the name {route} already exists")
+                raise ValueError(
+                    f"An audio stream with the name {route} already exists"
+                )
             self._audio_routes.append(route)
             self._app.router.add_route("GET", route, _AudioHandler(stream))
         else:
@@ -181,9 +183,7 @@ class Server:
                 for route in self._audio_routes:
                     print(f"http://{addr}:{self._port!s}{route}")
             if self._cap_routes and self._audio_routes:
-                print(
-                    f"\nPlayer: http://{addr}:{self._port!s}/player"
-                )
+                print(f"\nPlayer: http://{addr}:{self._port!s}/player")
             print("--------------------------------\n")
         print("\nPress Ctrl+C to stop the server\n")
 

--- a/mjpeg_streamer/stream.py
+++ b/mjpeg_streamer/stream.py
@@ -1,5 +1,6 @@
 import asyncio
 import struct
+import threading
 import time
 import uuid
 from collections import deque
@@ -311,6 +312,7 @@ class AudioStream:
         self._last_chunk: bytes = b""
         self._bandwidth_buffer: Deque[int] = deque(maxlen=sample_rate // chunk_size)
         self._bandwidth_last_modified_time: float = time.time()
+        self._first_chunk_ready: asyncio.Event = asyncio.Event()
         self._tasks: Dict[str, asyncio.Task] = {"_capture_loop": None}
 
     def _make_wav_header(self, data_size: int) -> bytes:
@@ -372,6 +374,8 @@ class AudioStream:
             try:
                 data = self._stream.read(self.chunk_size, exception_on_overflow=False)
                 self._last_chunk = data
+                if not self._first_chunk_ready.is_set():
+                    self._first_chunk_ready.set()
                 async with self._lock:
                     self._bandwidth_buffer.append(len(data))
                     self._bandwidth_last_modified_time = time.time()
@@ -401,6 +405,7 @@ class AudioStream:
         if self._is_running:
             print("Audio stream has already started")
             return
+        self._first_chunk_ready.clear()
         self._pa = pyaudio.PyAudio()
         self._stream = self._pa.open(
             format=pyaudio.paInt16 if self.sample_width == 2 else pyaudio.paInt8,
@@ -411,6 +416,13 @@ class AudioStream:
             frames_per_buffer=self.chunk_size,
         )
         self._is_running = True
+        thread = threading.Thread(target=self._run_capture_loop, daemon=True)
+        thread.start()
+
+    def _run_capture_loop(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(self._capture_loop())
 
     def stop(self) -> None:
         if not self._is_running:

--- a/mjpeg_streamer/stream.py
+++ b/mjpeg_streamer/stream.py
@@ -1,4 +1,5 @@
 import asyncio
+import struct
 import time
 import uuid
 from collections import deque
@@ -6,6 +7,13 @@ from typing import Deque, Dict, List, Optional, Set, Tuple, Union
 
 import cv2
 import numpy as np
+
+try:
+    import pyaudio
+
+    _HAS_PYAUDIO = True
+except ImportError:
+    _HAS_PYAUDIO = False
 
 
 class StreamBase:
@@ -270,3 +278,156 @@ class ManagedStream(StreamBase):
             self._cap_is_open = False
         else:
             print("Stream has already stopped")
+
+
+class AudioStream:
+    def __init__(
+        self,
+        name: str,
+        source: Optional[int] = None,
+        sample_rate: int = 44100,
+        channels: int = 1,
+        sample_width: int = 2,
+        chunk_size: int = 1024,
+        format: str = "wav",
+    ) -> None:
+        if not _HAS_PYAUDIO:
+            raise ImportError(
+                "pyaudio is required for audio streaming. "
+                "Install it with: pip install pyaudio"
+            )
+        self.name = name.casefold().replace(" ", "_")
+        self.source = source
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self.sample_width = sample_width
+        self.chunk_size = chunk_size
+        self.format = format
+        self._active_viewers: Set[str] = set()
+        self._lock: asyncio.Lock = asyncio.Lock()
+        self._is_running: bool = False
+        self._pa: Optional[pyaudio.PyAudio] = None
+        self._stream: Optional[pyaudio.Stream] = None
+        self._last_chunk: bytes = b""
+        self._bandwidth_buffer: Deque[int] = deque(maxlen=sample_rate // chunk_size)
+        self._bandwidth_last_modified_time: float = time.time()
+        self._tasks: Dict[str, asyncio.Task] = {"_capture_loop": None}
+
+    def _make_wav_header(self, data_size: int) -> bytes:
+        """Build a minimal WAV header for chunked streaming."""
+        byte_rate = self.sample_rate * self.channels * self.sample_width
+        block_align = self.channels * self.sample_width
+        header = struct.pack(
+            "<4sI4s4sIHHIIHH4sI",
+            b"RIFF",
+            36 + data_size,
+            b"WAVE",
+            b"fmt ",
+            16,
+            1,  # PCM
+            self.channels,
+            self.sample_rate,
+            byte_rate,
+            block_align,
+            self.sample_width * 8,
+            b"data",
+            data_size,
+        )
+        return header
+
+    def _make_wav_header_bytes(self) -> bytes:
+        """WAV header for an infinitely large stream."""
+        byte_rate = self.sample_rate * self.channels * self.sample_width
+        block_align = self.channels * self.sample_width
+        return struct.pack(
+            "<4sI4s4sIHHIIHH4sI",
+            b"RIFF",
+            0xFFFFFFFF,
+            b"WAVE",
+            b"fmt ",
+            16,
+            1,
+            self.channels,
+            self.sample_rate,
+            byte_rate,
+            block_align,
+            self.sample_width * 8,
+            b"data",
+            0xFFFFFFFF,
+        )
+
+    async def _ensure_background_tasks(self) -> None:
+        for task_name, task in self._tasks.items():
+            if task is None or task.done():
+                self._tasks[task_name] = asyncio.create_task(
+                    eval(f"self.{task_name}()")
+                )
+
+    async def _capture_loop(self) -> None:
+        """Background task that continuously reads audio from the device."""
+        while True:
+            if not self._is_running:
+                await asyncio.sleep(0.1)
+                continue
+            try:
+                data = self._stream.read(self.chunk_size, exception_on_overflow=False)
+                self._last_chunk = data
+                async with self._lock:
+                    self._bandwidth_buffer.append(len(data))
+                    self._bandwidth_last_modified_time = time.time()
+            except Exception:
+                await asyncio.sleep(0.1)
+
+    async def _add_viewer(self, viewer_token: Optional[str] = None) -> str:
+        viewer_token = viewer_token or str(uuid.uuid4())
+        async with self._lock:
+            self._active_viewers.add(viewer_token)
+        return viewer_token
+
+    async def _remove_viewer(self, viewer_token: str) -> None:
+        async with self._lock:
+            self._active_viewers.discard(viewer_token)
+
+    def has_demand(self) -> bool:
+        return len(self._active_viewers) > 0
+
+    def active_viewers(self) -> int:
+        return len(self._active_viewers)
+
+    def get_bandwidth(self) -> float:
+        return sum(self._bandwidth_buffer)
+
+    def start(self) -> None:
+        if self._is_running:
+            print("Audio stream has already started")
+            return
+        self._pa = pyaudio.PyAudio()
+        self._stream = self._pa.open(
+            format=pyaudio.paInt16 if self.sample_width == 2 else pyaudio.paInt8,
+            channels=self.channels,
+            rate=self.sample_rate,
+            input=True,
+            input_device_index=self.source,
+            frames_per_buffer=self.chunk_size,
+        )
+        self._is_running = True
+
+    def stop(self) -> None:
+        if not self._is_running:
+            print("Audio stream has already stopped")
+            return
+        self._is_running = False
+        for task in self._tasks.values():
+            if task and not task.done():
+                task.cancel()
+        if self._stream:
+            self._stream.stop_stream()
+            self._stream.close()
+        if self._pa:
+            self._pa.terminate()
+
+    def settings(self) -> None:
+        for key, value in self.__dict__.items():
+            if key.startswith("_"):
+                continue
+            print(f"{key}: {value}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ dependencies = [
   'opencv-python==4.8.1.78; python_version >= "3.7" and python_version <= "3.8"',
   'opencv-python; python_version >= "3.9"',
 ]
+
+[project.optional-dependencies]
+audio = ["pyaudio"]
 [project.urls]
 Homepage = "https://github.com/egeakman/mjpeg-streamer"
 Issues = "https://github.com/egeakman/mjpeg-streamer/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,10 @@ dependencies = [
   'opencv-python==4.8.1.78; python_version >= "3.7" and python_version <= "3.8"',
   'opencv-python; python_version >= "3.9"',
 ]
-
 [project.optional-dependencies]
-audio = ["pyaudio"]
+audio = [
+  "pyaudio",
+]
 [project.urls]
 Homepage = "https://github.com/egeakman/mjpeg-streamer"
 Issues = "https://github.com/egeakman/mjpeg-streamer/issues"

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -87,7 +87,9 @@ class TestWavHeader:
 
     def test_stereo_header(self):
         with patch("mjpeg_streamer.stream.pyaudio"):
-            stream = AudioStream("stereo", channels=2, sample_width=2, sample_rate=44100)
+            stream = AudioStream(
+                "stereo", channels=2, sample_width=2, sample_rate=44100
+            )
         header = stream._make_wav_header_bytes()
         channels = struct.unpack_from("<H", header, 22)[0]
         byte_rate = struct.unpack_from("<I", header, 28)[0]
@@ -99,9 +101,7 @@ class TestWavHeader:
 
 class TestViewerLifecycle:
     def test_add_viewer(self, audio_stream):
-        token = asyncio.get_event_loop().run_until_complete(
-            audio_stream._add_viewer()
-        )
+        token = asyncio.get_event_loop().run_until_complete(audio_stream._add_viewer())
         assert isinstance(token, str)
         assert len(token) > 0
         assert audio_stream.active_viewers() == 1
@@ -112,9 +112,7 @@ class TestViewerLifecycle:
         assert audio_stream.active_viewers() == 2
 
     def test_remove_viewer(self, audio_stream):
-        token = asyncio.get_event_loop().run_until_complete(
-            audio_stream._add_viewer()
-        )
+        token = asyncio.get_event_loop().run_until_complete(audio_stream._add_viewer())
         asyncio.get_event_loop().run_until_complete(audio_stream._remove_viewer(token))
         assert audio_stream.active_viewers() == 0
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,199 @@
+"""Unit tests for AudioStream."""
+
+import asyncio
+import struct
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mjpeg_streamer.stream import AudioStream
+
+
+@pytest.fixture
+def audio_stream():
+    with patch("mjpeg_streamer.stream.pyaudio"):
+        return AudioStream(
+            name="test_audio",
+            source=0,
+            sample_rate=44100,
+            channels=1,
+            sample_width=2,
+            chunk_size=1024,
+        )
+
+
+class TestWavHeader:
+    def test_header_length(self, audio_stream):
+        header = audio_stream._make_wav_header_bytes()
+        assert len(header) == 44
+
+    def test_riff_chunk(self, audio_stream):
+        header = audio_stream._make_wav_header_bytes()
+        assert header[0:4] == b"RIFF"
+        # Size field = 0xFFFFFFFF for streaming
+        riff_size = struct.unpack_from("<I", header, 4)[0]
+        assert riff_size == 0xFFFFFFFF
+
+    def test_waveFormat(self, audio_stream):
+        header = audio_stream._make_wav_header_bytes()
+        assert header[8:12] == b"WAVE"
+        assert header[12:16] == b"fmt "
+
+    def test_pcm_format(self, audio_stream):
+        header = audio_stream._make_wav_header_bytes()
+        # fmt chunk: audio format at offset 20 (after RIFF(8) + "WAVE"(4) + "fmt "(4) + chunk size(4))
+        audio_format = struct.unpack_from("<H", header, 20)[0]
+        assert audio_format == 1  # PCM
+
+    def test_channels(self, audio_stream):
+        header = audio_stream._make_wav_header_bytes()
+        channels = struct.unpack_from("<H", header, 22)[0]
+        assert channels == 1
+
+    def test_sample_rate(self, audio_stream):
+        header = audio_stream._make_wav_header_bytes()
+        sample_rate = struct.unpack_from("<I", header, 24)[0]
+        assert sample_rate == 44100
+
+    def test_byte_rate(self, audio_stream):
+        header = audio_stream._make_wav_header_bytes()
+        byte_rate = struct.unpack_from("<I", header, 28)[0]
+        # 44100 * 1 * 2 = 88200
+        assert byte_rate == 88200
+
+    def test_block_align(self, audio_stream):
+        header = audio_stream._make_wav_header_bytes()
+        block_align = struct.unpack_from("<H", header, 32)[0]
+        # 1 * 2 = 2
+        assert block_align == 2
+
+    def test_bits_per_sample(self, audio_stream):
+        header = audio_stream._make_wav_header_bytes()
+        bits = struct.unpack_from("<H", header, 34)[0]
+        assert bits == 16
+
+    def test_data_chunk(self, audio_stream):
+        header = audio_stream._make_wav_header_bytes()
+        assert header[36:40] == b"data"
+        data_size = struct.unpack_from("<I", header, 40)[0]
+        assert data_size == 0xFFFFFFFF  # streaming
+
+    def test_header_with_known_data_size(self, audio_stream):
+        header = audio_stream._make_wav_header(88200)
+        riff_size = struct.unpack_from("<I", header, 4)[0]
+        assert riff_size == 36 + 88200
+        data_size = struct.unpack_from("<I", header, 40)[0]
+        assert data_size == 88200
+
+    def test_stereo_header(self):
+        with patch("mjpeg_streamer.stream.pyaudio"):
+            stream = AudioStream("stereo", channels=2, sample_width=2, sample_rate=44100)
+        header = stream._make_wav_header_bytes()
+        channels = struct.unpack_from("<H", header, 22)[0]
+        byte_rate = struct.unpack_from("<I", header, 28)[0]
+        block_align = struct.unpack_from("<H", header, 32)[0]
+        assert channels == 2
+        assert byte_rate == 44100 * 2 * 2  # 176400
+        assert block_align == 2 * 2  # 4
+
+
+class TestViewerLifecycle:
+    def test_add_viewer(self, audio_stream):
+        token = asyncio.get_event_loop().run_until_complete(
+            audio_stream._add_viewer()
+        )
+        assert isinstance(token, str)
+        assert len(token) > 0
+        assert audio_stream.active_viewers() == 1
+
+    def test_add_multiple_viewers(self, audio_stream):
+        asyncio.get_event_loop().run_until_complete(audio_stream._add_viewer())
+        asyncio.get_event_loop().run_until_complete(audio_stream._add_viewer("custom"))
+        assert audio_stream.active_viewers() == 2
+
+    def test_remove_viewer(self, audio_stream):
+        token = asyncio.get_event_loop().run_until_complete(
+            audio_stream._add_viewer()
+        )
+        asyncio.get_event_loop().run_until_complete(audio_stream._remove_viewer(token))
+        assert audio_stream.active_viewers() == 0
+
+    def test_remove_nonexistent_viewer(self, audio_stream):
+        asyncio.get_event_loop().run_until_complete(
+            audio_stream._remove_viewer("nonexistent")
+        )
+        assert audio_stream.active_viewers() == 0
+
+    def test_has_demand(self, audio_stream):
+        assert not audio_stream.has_demand()
+        asyncio.get_event_loop().run_until_complete(audio_stream._add_viewer())
+        assert audio_stream.has_demand()
+
+
+class TestBandwidth:
+    def test_initial_bandwidth(self, audio_stream):
+        assert audio_stream.get_bandwidth() == 0
+
+    def test_bandwidth_after_chunks(self, audio_stream):
+        audio_stream._bandwidth_buffer.append(1024)
+        audio_stream._bandwidth_buffer.append(2048)
+        assert audio_stream.get_bandwidth() == 3072
+
+
+class TestStartStop:
+    def test_start_sets_running(self, audio_stream):
+        audio_stream.start()
+        assert audio_stream._is_running
+        audio_stream.stop()
+
+    def test_stop_clears_running(self, audio_stream):
+        audio_stream.start()
+        audio_stream.stop()
+        assert not audio_stream._is_running
+
+    def test_double_start(self, audio_stream, capsys):
+        audio_stream.start()
+        audio_stream.start()  # should print warning
+        captured = capsys.readouterr()
+        assert "already started" in captured.out
+        audio_stream.stop()
+
+    def test_double_stop(self, audio_stream, capsys):
+        audio_stream.start()
+        audio_stream.stop()
+        audio_stream.stop()  # should print warning
+        captured = capsys.readouterr()
+        assert "already stopped" in captured.out
+
+    def test_first_chunk_event_clears_on_start(self, audio_stream):
+        audio_stream._first_chunk_ready.set()
+        audio_stream.start()
+        assert not audio_stream._first_chunk_ready.is_set()
+        audio_stream.stop()
+
+
+class TestSettings:
+    def test_settings_prints_public_attrs(self, audio_stream, capsys):
+        audio_stream.settings()
+        captured = capsys.readouterr()
+        assert "name" in captured.out
+        assert "sample_rate" in captured.out
+        assert "channels" in captured.out
+
+    def test_settings_skips_private_attrs(self, audio_stream, capsys):
+        audio_stream.settings()
+        captured = capsys.readouterr()
+        assert "_lock" not in captured.out
+        assert "_pa" not in captured.out
+
+
+class TestNameNormalization:
+    def test_name_lowercased(self):
+        with patch("mjpeg_streamer.stream.pyaudio"):
+            stream = AudioStream("MyAudio")
+        assert stream.name == "myaudio"
+
+    def test_spaces_replaced(self):
+        with patch("mjpeg_streamer.stream.pyaudio"):
+            stream = AudioStream("My Audio Stream")
+        assert stream.name == "my_audio_stream"


### PR DESCRIPTION
- Add AudioStream class for capturing and streaming audio via PyAudio
- Add _AudioHandler to serve WAV audio streams over HTTP
- Add built-in HTML player page (/player) with synced audio+video
- Add --audio, --audio-device, --audio-rate, --audio-channels CLI flags
- Add --list-devices flag to show available audio input devices
- Add pyaudio as optional dependency (pip install mjpeg-streamer[audio])
- Update README with audio documentation and examples